### PR TITLE
Update moonscript_release workflow to 0.30

### DIFF
--- a/.github/workflows/moonscript_release.yml
+++ b/.github/workflows/moonscript_release.yml
@@ -33,9 +33,6 @@ jobs:
       - name: Remove github dir
         run: rm -rf .github
 
-      - name: Remove .gitignore
-        run: rm -rf .gitignore
-
       - name: Create VERSION file
         run: versionStr=${{ github.ref }};echo -e v${versionStr#*v} > VERSION
 


### PR DESCRIPTION
This PR was automatically triggered due to [a change in the base `moonscript_release` workflow](https://github.com/CFC-Servers/github_action_workflows/compare/0.29.2..0.30)